### PR TITLE
feat(renovate): automerge digest updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,7 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }
   ],


### PR DESCRIPTION
This allows automerge on all digest updates.
This means, if the node:20.x.y got a new image of the same version, its gonna automerge that.
That happens around 3 times per week and we alwways have to merge manually right now. Which is annoying